### PR TITLE
Fix: Spelling mistake in the package.json license #52

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon node index.js"
   },
   "author": "Srujan Deshpande (srujan.deshpande@gmail.com)",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.21.1",
     "discord.js": "^12.5.3",


### PR DESCRIPTION
Fixed the spelling error - missing hyphen in the package license text. Added the missing hyphen as resolution.